### PR TITLE
ci: fix mjai-reviewer download (releases are all prereleases)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,13 +58,31 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path gui/vendor | Out-Null
           New-Item -ItemType Directory -Force -Path mjai_tmp | Out-Null
-          gh release download --repo $env:MJAI_REPO --pattern "*windows*.zip" --dir mjai_tmp
-          $zip = Get-ChildItem mjai_tmp -Filter *.zip | Select-Object -First 1
-          if ($null -eq $zip) { Write-Error "找不到 mjai-reviewer 的 Windows 版 zip 資產"; exit 1 }
-          Expand-Archive -Path $zip.FullName -DestinationPath mjai_tmp/extracted -Force
-          $exe = Get-ChildItem mjai_tmp/extracted -Recurse -Filter mjai-reviewer.exe | Select-Object -First 1
-          if ($null -eq $exe) { Write-Error "解壓後找不到 mjai-reviewer.exe"; exit 1 }
+          # mjai-reviewer 的 release 全部標記為 prerelease，`gh release download`（取 latest）
+          # 會回 "release not found"。改用 API 列出所有 release，挑最新一個含 Windows zip 的資產。
+          $headers = @{
+            'User-Agent'    = 'gh-actions'
+            'Accept'        = 'application/vnd.github+json'
+            'Authorization' = "Bearer $env:GH_TOKEN"
+          }
+          $releases = Invoke-RestMethod -Headers $headers -Uri "https://api.github.com/repos/$env:MJAI_REPO/releases?per_page=20"
+          $asset = $null
+          foreach ($r in $releases) {
+            $a = $r.assets | Where-Object { $_.name -match 'windows' -and $_.name -match '\.zip$' } | Select-Object -First 1
+            if ($a) { $asset = $a; break }
+          }
+          if ($null -eq $asset) { Write-Error "找不到 mjai-reviewer 的 Windows zip 資產"; exit 1 }
+          Write-Host "下載資產: $($asset.name)"
+          # browser_download_url 會轉址到 githubusercontent；下載本身不帶 Authorization（帶了會被拒）。
+          Invoke-WebRequest -Uri $asset.browser_download_url -OutFile mjai_tmp/mjai.zip
+          Expand-Archive -Path mjai_tmp/mjai.zip -DestinationPath mjai_tmp/extracted -Force
+          # 預編譯執行檔可能叫 mjai-reviewer.exe 或 akochan-reviewer.exe（mjai-reviewer 的前身），
+          # 對 `--no-review --mjai-out` 的純轉換用法相容；取任一 reviewer exe，統一命名為 mjai-reviewer.exe。
+          $exe = Get-ChildItem mjai_tmp/extracted -Recurse -Include 'mjai-reviewer.exe', 'akochan-reviewer.exe' | Select-Object -First 1
+          if ($null -eq $exe) { $exe = Get-ChildItem mjai_tmp/extracted -Recurse -Filter '*reviewer*.exe' | Select-Object -First 1 }
+          if ($null -eq $exe) { Write-Error "解壓後找不到 reviewer 執行檔"; exit 1 }
           Copy-Item $exe.FullName gui/vendor/mjai-reviewer.exe -Force
+          Write-Host "已放置 gui/vendor/mjai-reviewer.exe (來源: $($exe.Name))"
 
       - name: Backend smoke test (NDJSON protocol)
         shell: pwsh


### PR DESCRIPTION
## 問題

合併 #6 後，main 的 `build-release` 首次執行**失敗**（[run #1](https://github.com/jeff39389327/MajsoulPaipuConvert/actions/runs/27089753383)）。失敗點在 **mjai-reviewer 下載步驟**：

```
release not found
找不到 mjai-reviewer 的 Windows 版 zip 資產
```

（pip 安裝、移除 asyncio backport、pyinstaller 安裝都成功了，所以 PyInstaller 凍結本身尚未測到。）

## 根因

`Equim-chan/mjai-reviewer` 的 **19 個 release 全部標記為 `prerelease`**。`gh release download`（不指定 tag 時取「latest」）只認非 prerelease 的版本，因此回 `release not found`。Windows 資產實際命名為 `akochan-reviewer-vX-windows-x86_64.zip`，內含 `akochan-reviewer.exe`（mjai-reviewer 的前身，`--no-review --mjai-out` 純轉換用法相容）。

## 修法

改用 REST API：

1. `GET /releases`（含 prerelease），挑**最新一個帶 Windows `*.zip` 資產**的 release。
2. 用 `browser_download_url` 下載（**不帶** Authorization header——轉址到 githubusercontent 會拒帶 token 的請求）。
3. 解壓後取 `mjai-reviewer.exe` / `akochan-reviewer.exe`（或任一 `*reviewer*.exe`），統一放成 `gui/vendor/mjai-reviewer.exe`。

## 備註

- 這修好的是 CI 取得 mjai 的環節；**PyInstaller 凍結 + electron-builder 是否一次過，要等這步通過後的下一輪才知道**。若再卡，我會繼續在此分支或新分支迭代。
- 已在本機用 GitHub API 驗證 release 結構與 zip 內容（`akochan-reviewer.exe` 20MB + `akochan/` 引擎資料夾；`--no-review` 純轉換不需該引擎）。

https://claude.ai/code/session_011snFovAJNLvVJ2ufDiguPk

---
_Generated by [Claude Code](https://claude.ai/code/session_011snFovAJNLvVJ2ufDiguPk)_