### PR TITLE
fix: force UTF-8 stdout (Windows build + frozen app crash on CJK)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Install GUI deps & build (freeze backend + electron-builder)
         shell: pwsh
         working-directory: gui
+        env:
+          PYTHONUTF8: '1'
+          PYTHONIOENCODING: utf-8
         run: |
           npm install
           npm run dist

--- a/gui/backend/bridge.py
+++ b/gui/backend/bridge.py
@@ -29,6 +29,15 @@ import os
 import sys
 from datetime import datetime, timezone
 
+# NDJSON 事件含非 ASCII（中文 msg 等）。Windows 上被 Electron spawn 時，stdout/stderr 是
+# 管道、預設用 cp1252 編碼，寫中文會 UnicodeEncodeError。強制 UTF-8（與 Electron 端 readline
+# 的 utf-8 解碼一致）。
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
 # 在任何 print 重導之前，保存真正的 stdout 給事件流使用。
 _EVENT_OUT = sys.stdout
 # 之後所有 print()（含 import 進來的既有模組）一律導向 stderr，保持 stdout 乾淨。

--- a/gui/build/freeze_backend.py
+++ b/gui/build/freeze_backend.py
@@ -12,6 +12,13 @@ import os
 import subprocess
 import sys
 
+# Windows 預設 stdout 編碼為 cp1252，print 中文會 UnicodeEncodeError；強制 UTF-8。
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
 GUI_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 REPO_ROOT = os.path.dirname(GUI_DIR)
 SPEC = os.path.join(GUI_DIR, "build", "backend.spec")


### PR DESCRIPTION
## 問題

build-release run #2（merge #7 後）**通過了 mjai 下載**（已成功抓 `akochan-reviewer-v0.7.1`、放置 exe、smoke 測試 PASS、npm install OK），但在 `npm run dist → freeze` 失敗：

```
UnicodeEncodeError: 'charmap' codec can't encode characters ...
  File "gui/build/freeze_backend.py", line 42, in main
    print("[freeze] 執行:", " ".join(cmd))
```

Windows 預設 stdout 編碼是 **cp1252**，`print` 中文就崩潰——PyInstaller 根本還沒開始跑。

## 同樣的隱患在 runtime

凍結後的 `backend.exe` 會把 NDJSON 事件（含中文 `msg`）寫到 Electron spawn 的**管道**；Electron 端以 UTF-8 解碼，但 Python 在 Windows 上會用 cp1252 編碼 → 同樣 `UnicodeEncodeError`。所以這不只是 build 問題，也是 app 在 Windows 的潛在崩潰。

## 修法

- `freeze_backend.py` 與 `gui/backend/bridge.py` 開頭都 `sys.stdout/sys.stderr.reconfigure(encoding="utf-8")`。
- build 步驟加 `PYTHONUTF8=1` / `PYTHONIOENCODING=utf-8` 雙保險。

## 驗證

本機 `py_compile`、YAML、`node gui/test/smoke.js` 皆通過（bridge 改動後 NDJSON 仍正常）。

> 這修好後，下一輪 build 才會**首次真正執行 PyInstaller 凍結**；若 hidden-import 還有缺，我會繼續迭代。

https://claude.ai/code/session_011snFovAJNLvVJ2ufDiguPk

---
_Generated by [Claude Code](https://claude.ai/code/session_011snFovAJNLvVJ2ufDiguPk)_