### PR TITLE
fix(crawler): tolerate TLS-intercepting egress proxies (Selenium)

### DIFF
--- a/paipu_project/paipu_project/spiders/PaipuSpider.py
+++ b/paipu_project/paipu_project/spiders/PaipuSpider.py
@@ -236,6 +236,11 @@ def create_stealth_driver(headless_mode: bool, extra_args: List[str] = None):
     chrome_options.add_argument("--disable-gpu")
     chrome_options.add_argument("--disable-software-rasterizer")
 
+    # Tolerate TLS-intercepting egress proxies (sandbox / CI environments). Without this,
+    # Chrome shows a "Your connection is not private" interstitial and no page content loads.
+    chrome_options.add_argument("--ignore-certificate-errors")
+    chrome_options.set_capability("acceptInsecureCerts", True)
+
     # Disable various features that may cause conflicts
     chrome_options.add_argument("--disable-extensions")
     chrome_options.add_argument("--disable-background-networking")


### PR DESCRIPTION
## 摘要

只挑 `claude/env-setup-download-MrZcM` 分支裡那段 **5 行 TLS 修正** 進 main，其餘（setup_env.sh、pipeline.yml、tests 等）**不要**。

## 改動

`create_stealth_driver` 的 Chrome options 加上：

```python
chrome_options.add_argument("--ignore-certificate-errors")
chrome_options.set_capability("acceptInsecureCerts", True)
```

讓 Selenium 爬蟲在 **TLS 攔截代理**（sandbox / CI 出口代理）下也能運作——否則 Chrome 會卡在「您的連線不是私人連線」攔截頁，抓不到任何內容。

## 備註

- 純手動 cherry-pick（只 5 行），不含該分支其他檔案。
- 與既有 `PaipuSpider.py` 的 GUI 凍結改動不衝突（不同函式/段落）。
- 合併後 `claude/env-setup-download-MrZcM` 分支即可刪除（其唯一想保留的部分已納入）。

https://claude.ai/code/session_011snFovAJNLvVJ2ufDiguPk

---
_Generated by [Claude Code](https://claude.ai/code/session_011snFovAJNLvVJ2ufDiguPk)_