### PR TITLE
Remove dry-run; fix Stage 1 crawl and GUI responsiveness

### DIFF
--- a/gui/backend/run_crawler.py
+++ b/gui/backend/run_crawler.py
@@ -38,23 +38,6 @@ def _write_config(params: dict) -> str:
     return str((paths.inner_dir(params) / output_filename).resolve())
 
 
-def _dry_run(params: dict, output_path: str) -> None:
-    """不啟動 scrapy/selenium，產生假 ID 驗證事件序列與檔案寫入。"""
-    cfg = params.get("config") or {}
-    bridge.stage_start("crawl", mode=cfg.get("crawler_mode", "auto"))
-    seen = set()
-    with open(output_path, "a", encoding="utf-8") as out:
-        for i in range(5):
-            fake = f"24010{i}-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-            if fake not in seen:
-                seen.add(fake)
-                out.write(fake + "\n")
-                out.flush()
-                bridge.progress("crawl", unit="id", count=len(seen), total=None, current=fake)
-    bridge.stage_done("crawl", collected=len(seen), output_file=output_path)
-    bridge.done(ok=True)
-
-
 def _run_scrapy_cli(params: dict, output_path: str) -> None:
     """dev 模式：以子程序執行 `scrapy crawl paipu_spider`，解析 stdout 統計進度。"""
     cfg = params.get("config") or {}
@@ -62,8 +45,11 @@ def _run_scrapy_cli(params: dict, output_path: str) -> None:
 
     env = os.environ.copy()
     env["PYTHONIOENCODING"] = "utf-8"
+    # 以「正在跑後端的同一個 Python」呼叫 scrapy：GUI 用 .venv/Scripts/python.exe 啟動本
+    # 程序，但 venv 的 Scripts/ 不在 PATH 上，裸 `scrapy` 會 FileNotFoundError。-m scrapy
+    # 必用該直譯器的 scrapy，與其相依一致。(此分支僅 dev 模式走到，sys.executable 即 venv python。)
     proc = subprocess.Popen(
-        ["scrapy", "crawl", "paipu_spider"],
+        [sys.executable, "-m", "scrapy", "crawl", "paipu_spider"],
         cwd=str(paths.inner_dir(params)),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -128,9 +114,7 @@ def _run_scrapy_frozen(params: dict, output_path: str) -> None:
 def run(params: dict) -> None:
     output_path = _write_config(params)
     try:
-        if bridge.has_flag("--dry-run"):
-            _dry_run(params, output_path)
-        elif bridge.is_frozen():
+        if bridge.is_frozen():
             _run_scrapy_frozen(params, output_path)
         else:
             _run_scrapy_cli(params, output_path)

--- a/gui/backend/run_download.py
+++ b/gui/backend/run_download.py
@@ -51,18 +51,6 @@ def _bool_env(name: str, default: bool) -> bool:
     return os.getenv(name, str(default)).lower() == "true"
 
 
-def _dry_run(params: dict, ids: list[str]) -> None:
-    """不登入、不下載，僅驗證事件序列。"""
-    bridge.stage_start("download")
-    sample = ids[:3] if ids else [f"24010{i}-aaaa-bbbb-cccc-dddd-eeeeeeeeeeee" for i in range(3)]
-    total = len(sample)
-    for n, uuid in enumerate(sample, 1):
-        bridge.progress("download", phase="download", done=n, total=total, uuid=uuid, ok=True)
-        bridge.progress("convert", phase="mjai", done=n, total=total, uuid=uuid, ok=True)
-    bridge.stage_done("download", downloaded=total, total=total)
-    bridge.done(ok=True)
-
-
 async def _run_async(params: dict, work_dir: str, repo_root: str) -> None:
     import dotenv
 
@@ -158,10 +146,6 @@ def run(params: dict) -> None:
     work_dir = str(paths.work_dir(params))
     repo_root = str(paths.repo_root(params))
     paths.ensure_repo_on_syspath(params)
-
-    if bridge.has_flag("--dry-run"):
-        _dry_run(params, _read_id_list(params, work_dir))
-        return
 
     try:
         asyncio.run(_run_async(params, work_dir, repo_root))

--- a/gui/electron/main.js
+++ b/gui/electron/main.js
@@ -141,7 +141,7 @@ function registerIpc() {
     return configStore.writeCrawlerConfig(innerDir, cfg || {});
   });
 
-  ipcMain.handle('job:start', (_e, { kind, params, dryRun }) => {
+  ipcMain.handle('job:start', (_e, { kind, params }) => {
     const { repoRoot, workDir, innerDir } = derivePaths();
     const merged = Object.assign(
       { repo_root: repoRoot, work_dir: workDir, inner_dir: innerDir },
@@ -153,7 +153,7 @@ function registerIpc() {
       if (settings.convertConcurrency) merged.convert_concurrency = settings.convertConcurrency;
       merged.sequential_download = !!settings.sequentialDownload;
     }
-    return pyRunner.startJob(kind, { params: merged, dryRun, pythonPath: settings.pythonPath }, send);
+    return pyRunner.startJob(kind, { params: merged, pythonPath: settings.pythonPath }, send);
   });
 
   ipcMain.handle('job:cancel', () => pyRunner.cancelJob());

--- a/gui/electron/preload.js
+++ b/gui/electron/preload.js
@@ -19,7 +19,7 @@ contextBridge.exposeInMainWorld('api', {
   writeCrawler: (cfg) => ipcRenderer.invoke('config:writeCrawler', cfg),
 
   // job 控制
-  startJob: (kind, params, dryRun) => ipcRenderer.invoke('job:start', { kind, params, dryRun }),
+  startJob: (kind, params) => ipcRenderer.invoke('job:start', { kind, params }),
   cancelJob: () => ipcRenderer.invoke('job:cancel'),
 
   // 事件訂閱 (回傳取消訂閱函式)

--- a/gui/electron/pyRunner.js
+++ b/gui/electron/pyRunner.js
@@ -16,7 +16,7 @@ function isRunning() {
 }
 
 // 啟動一個 job。send(channel, payload) 用來把事件推給 renderer。
-// kind: 'crawl' | 'download' | 'doctor'；options: { params, dryRun, pythonPath, cwd }
+// kind: 'crawl' | 'download' | 'doctor'；options: { params, pythonPath, cwd }
 function startJob(kind, options, send) {
   if (current) {
     send('py:event', { type: 'error', code: 'BUSY', msg: 'a job is already running', fatal: true });
@@ -30,7 +30,6 @@ function startJob(kind, options, send) {
   }
 
   const args = [...backend.baseArgs, kind, '--params-stdin'];
-  if (options.dryRun) args.push('--dry-run');
 
   const child = spawn(backend.command, args, {
     cwd: options.cwd || backend.cwd,

--- a/gui/renderer/app.js
+++ b/gui/renderer/app.js
@@ -32,10 +32,25 @@ function onJobEvent(cb) {
   return () => jobHandlers.delete(cb);
 }
 
+// log 轉送可能極高頻（如 scrapy/selenium DEBUG 洪流）。若每行都直接寫 DOM 並無上限累加，
+// renderer 主執行緒會被拖垮，導致「取消」鈕點不動、狀態也更新不了。對策：(1) 緩衝字串設上限，
+// (2) 用 requestAnimationFrame 把多次寫入合併成每幀一次 DOM 更新，讓事件迴圈保持可回應點擊。
+const LOG_MAX_CHARS = 200000;
+let logBuffer = '';
+let logFlushScheduled = false;
 function appendLog(text) {
-  const drawer = document.getElementById('log-drawer');
-  drawer.textContent += text.endsWith('\n') ? text : text + '\n';
-  drawer.scrollTop = drawer.scrollHeight;
+  logBuffer += text.endsWith('\n') ? text : text + '\n';
+  if (logBuffer.length > LOG_MAX_CHARS) {
+    logBuffer = logBuffer.slice(logBuffer.length - LOG_MAX_CHARS);
+  }
+  if (logFlushScheduled) return;
+  logFlushScheduled = true;
+  requestAnimationFrame(() => {
+    logFlushScheduled = false;
+    const drawer = document.getElementById('log-drawer');
+    drawer.textContent = logBuffer;
+    drawer.scrollTop = drawer.scrollHeight;
+  });
 }
 
 function setStatus(status) {
@@ -48,7 +63,7 @@ function setStatus(status) {
 
 // 啟動 job 並回傳 Promise。終止路徑有三：done 事件、startJob 回傳 false、或後端在未發出
 // done 前就 py:exit（取消/匯入期崩潰）。任一路徑都會解除訂閱並 resolve，避免殘留 handler。
-function runJob(kind, params, dryRun, onEvent) {
+function runJob(kind, params, onEvent) {
   return new Promise((resolve) => {
     setStatus('running');
     let settled = false;
@@ -74,7 +89,7 @@ function runJob(kind, params, dryRun, onEvent) {
       if (state.jobStatus === 'running') setStatus(info && info.code === 0 ? 'done' : 'error');
       finish({ type: 'done', ok: false, viaExit: true });
     });
-    window.api.startJob(kind, params || {}, !!dryRun).then((ok) => {
+    window.api.startJob(kind, params || {}).then((ok) => {
       if (!ok) {
         setStatus('error');
         finish({ type: 'done', ok: false });
@@ -101,7 +116,7 @@ async function refreshConfig() {
 
 async function runDoctor() {
   let result = null;
-  await runJob('doctor', {}, false, (ev) => {
+  await runJob('doctor', {}, (ev) => {
     if (ev.type === 'stage_done' && ev.stage === 'doctor') result = ev.stats;
   });
   state.doctor = result;

--- a/gui/renderer/views/step-crawl.js
+++ b/gui/renderer/views/step-crawl.js
@@ -1,5 +1,5 @@
 // step-crawl —— 執行 Stage 1（爬牌譜 ID）。不定量進度 + 可取消 + 完成後自動接到下載。
-import { h, toggle } from './dom.js';
+import { h } from './dom.js';
 import { buildConfig } from './step-mode.js';
 
 export function renderCrawl(ctx, container) {
@@ -20,11 +20,8 @@ export function renderCrawl(ctx, container) {
   const result = h('div');
   container.append(result);
 
-  let dryRun = false;
-  const dryToggle = toggle('dry-run', false, (v) => (dryRun = v));
-
   const startBtn = h('button', { class: 'primary' }, t('btn.start'));
-  const actions = h('div', { class: 'actions' }, startBtn, dryToggle);
+  const actions = h('div', { class: 'actions' }, startBtn);
   container.append(actions);
 
   // 訂閱 job 事件（離開此 view 時取消）
@@ -54,7 +51,7 @@ export function renderCrawl(ctx, container) {
     bar.classList.add('indeterminate');
     label.textContent = t('status.running');
     await ctx.api.writeCrawler(buildConfig(form));
-    await ctx.runJob('crawl', { config: buildConfig(form) }, dryRun);
+    await ctx.runJob('crawl', { config: buildConfig(form) });
     bar.classList.remove('indeterminate');
   };
 

--- a/gui/renderer/views/step-download.js
+++ b/gui/renderer/views/step-download.js
@@ -1,5 +1,5 @@
 // step-download —— 執行 Stage 2（並行下載 + mjai 轉換），雙進度條 + 即時摘要。
-import { h, toggle } from './dom.js';
+import { h } from './dom.js';
 
 export function renderDownload(ctx, container) {
   const { t, state } = ctx;
@@ -22,10 +22,8 @@ export function renderDownload(ctx, container) {
   container.append(result);
 
   let total = 0;
-  let dryRun = false;
-  const dryToggle = toggle('dry-run', false, (v) => (dryRun = v));
   const startBtn = h('button', { class: 'primary' }, t('btn.start'));
-  container.append(h('div', { class: 'actions' }, startBtn, dryToggle));
+  container.append(h('div', { class: 'actions' }, startBtn));
 
   const setBar = (bar, done, tot) => {
     const pct = tot ? Math.round((done / tot) * 100) : 0;
@@ -62,7 +60,7 @@ export function renderDownload(ctx, container) {
     label.textContent = t('status.running');
     const params = {};
     if (state.crawlOutputFile) params.input_list = state.crawlOutputFile;
-    await ctx.runJob('download', params, dryRun);
+    await ctx.runJob('download', params);
   };
 
   return off;

--- a/gui/test/smoke.js
+++ b/gui/test/smoke.js
@@ -1,11 +1,11 @@
 'use strict';
 // smoke —— 不需 Electron / Chrome / 雀魂，驗證後端 NDJSON 協定與事件順序。
 // 執行：node gui/test/smoke.js   (cwd 任意；會以 repo root 為後端 cwd)
+//
+// crawl/download 需真實 Selenium/登入，無法在煙霧測試中執行，故僅驗證 doctor 的事件序列。
 
 const { spawn } = require('child_process');
 const readline = require('readline');
-const os = require('os');
-const fs = require('fs');
 const path = require('path');
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -37,35 +37,12 @@ function assert(cond, msg) {
 }
 
 (async () => {
-  // 1) doctor --mock
+  // doctor --mock：驗證 NDJSON 事件序列 (stage_start … stage_done … done)
   const doctor = await runBackend(['doctor', '--mock', '--params-stdin'], {});
   const types = doctor.events.map((e) => e.type);
   assert(types[0] === 'stage_start', 'doctor: first event is stage_start');
   assert(types.includes('stage_done'), 'doctor: has stage_done');
   assert(types[types.length - 1] === 'done', 'doctor: last event is done');
 
-  // 2) crawl --dry-run -> 產生輸出檔
-  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'paipu-'));
-  const crawl = await runBackend(['crawl', '--dry-run', '--params-stdin'], {
-    repo_root: tmp,
-    work_dir: tmp,
-    config: { crawler_mode: 'date_room', start_date: '2024-01-01', end_date: '2024-01-01', target_room: 'Jade', output_filename: 'date_room_list.txt' },
-  });
-  const doneCrawl = crawl.events.find((e) => e.type === 'stage_done');
-  assert(doneCrawl && doneCrawl.stats.collected === 5, 'crawl: collected 5 ids');
-  const outFile = doneCrawl.stats.output_file;
-  assert(fs.existsSync(outFile), 'crawl: output file written');
-
-  // 3) download --dry-run，以 crawl 輸出為輸入清單 (自動銜接)
-  const dl = await runBackend(['download', '--dry-run', '--params-stdin'], {
-    repo_root: tmp, work_dir: tmp, input_list: outFile,
-  });
-  const dlTypes = dl.events.map((e) => e.type);
-  const phases = dl.events.filter((e) => e.type === 'progress').map((e) => e.phase);
-  assert(dlTypes[0] === 'stage_start', 'download: first event is stage_start');
-  assert(phases.includes('download') && phases.includes('mjai'), 'download: has download+mjai phases');
-  assert(dlTypes[dlTypes.length - 1] === 'done', 'download: last event is done');
-
-  fs.rmSync(tmp, { recursive: true, force: true });
   console.log(process.exitCode ? '\nSMOKE FAILED' : '\nSMOKE PASSED');
 })();

--- a/paipu_project/paipu_project/date_room_extractor.py
+++ b/paipu_project/paipu_project/date_room_extractor.py
@@ -14,8 +14,14 @@ import shutil
 import random
 import sys
 import io
+import logging
 
 from datetime import datetime
+
+# selenium 的 remote_connection logger 在 DEBUG 等級會把每個 WebDriver 指令（含整段注入 JS）
+# 印出來，形成 MB 級洪流灌爆 GUI 前端（拖垮主執行緒、取消鈕點不動）。提到 WARNING 止血。
+for _noisy_logger in ("selenium", "selenium.webdriver.remote.remote_connection", "urllib3"):
+    logging.getLogger(_noisy_logger).setLevel(logging.WARNING)
 
 # 強制設定 stdout 和 stderr 為 UTF-8 編碼
 if sys.stdout.encoding != 'utf-8':

--- a/paipu_project/paipu_project/spiders/PaipuSpider.py
+++ b/paipu_project/paipu_project/spiders/PaipuSpider.py
@@ -17,6 +17,15 @@ import tempfile
 import signal
 import random
 import traceback
+import logging
+
+# selenium 的 remote_connection logger 在 DEBUG 等級會把「每一個」WebDriver 指令（含整段
+# getAttribute 注入 JS，單筆數 KB）印出來。scrapy 預設 LOG_LEVEL=DEBUG，會讓它噴出 MB 級
+# 洪流，經由 GUI 逐行轉送到 renderer 並無上限累加進 DOM，拖垮前端主執行緒、導致「取消」鈕
+# 點不動、進度/狀態也更新不了。將 selenium / urllib3 logger 提到 WARNING 以止血（不影響
+# 我們自己的 print 進度輸出）。
+for _noisy_logger in ("selenium", "selenium.webdriver.remote.remote_connection", "urllib3"):
+    logging.getLogger(_noisy_logger).setLevel(logging.WARNING)
 
 @dataclass
 class CrawlerConfig:
@@ -703,6 +712,11 @@ def get_top_players_urls(config: CrawlerConfig):
                 driver.execute_script("arguments[0].click();", radio_button)
                 print(f"Clicked {period} time period")
 
+                # 切換時間段會觸發 React 重新抓取榜單，舊表會先被卸載 (玩家連結瞬間歸零)。
+                # 先沉澱片刻讓舊內容消失，再由 extract_positive_ranking_players 等新榜單
+                # 渲染完成；否則會在空表上抓取而收集到 0 筆。
+                time.sleep(1.5)
+
                 # Save verification screenshot
                 if config.save_screenshots:
                     rank_suffix = "_".join(config.ranks).lower()
@@ -752,65 +766,45 @@ def get_top_players_urls(config: CrawlerConfig):
         print("Chrome instance closed")
 
 def extract_positive_ranking_players(driver, period, config: CrawlerConfig):
-    """Extract player links from Positive ranking column"""
+    """Extract player links from the 'Positive ranking' column.
+
+    delta 排行榜頁渲染三欄 MuiGrid（Negative / Positive / Stamina ranking），每欄是一個
+    <h5> 標題後接一張玩家連結表。重點：切換時間段 radio 後 React 會卸載並重抓榜單，玩家
+    連結會瞬間歸零（見過往「Method 3 found 0」即此故），故**必須先等連結重新渲染**再抓，
+    否則讀到空表收集 0 筆。鎖定 Positive 欄的方式：用 <h5> 標題文字定位，取其父層 grid
+    item（恰好只包這一欄）內的 /player/ 連結——避免抓到 Negative 欄（輸最多的人）。
+    """
     player_urls = []
 
     try:
         print(f"Starting to find player links in Positive ranking column for time period {period}...")
 
-        # Method 1: Try to find player links in Positive ranking column
-        player_links_in_positive = []
-
+        # 等榜單（任一玩家連結）重新渲染完成
         try:
-            positive_heading = driver.find_element(By.XPATH, "//*[contains(text(), 'Positive ranking')]")
-            print("Found Positive ranking heading")
+            WebDriverWait(driver, 20).until(
+                EC.presence_of_element_located((By.CSS_SELECTOR, "a[href*='/player/']"))
+            )
+        except Exception:
+            print("Timed out waiting for player links to render after period switch")
 
-            positive_container = positive_heading.find_element(By.XPATH, "./following-sibling::*[1] | ./parent::*/following-sibling::*[1]")
-
-            container_links = positive_container.find_elements(By.CSS_SELECTOR, "a[href*='/player/']")
-            player_links_in_positive.extend(container_links)
-            print(f"Found {len(container_links)} player links in Positive ranking container")
-
+        # 以 'Positive ranking' 標題定位該欄，取其父 grid item 內的玩家連結
+        player_links_in_positive = []
+        try:
+            positive_heading = WebDriverWait(driver, 10).until(
+                EC.presence_of_element_located(
+                    (By.XPATH, "//h5[normalize-space(.)='Positive ranking']")
+                )
+            )
+            positive_column = positive_heading.find_element(By.XPATH, "./parent::*")
+            player_links_in_positive = positive_column.find_elements(
+                By.CSS_SELECTOR, "a[href*='/player/']"
+            )
+            print(f"Found {len(player_links_in_positive)} player links in Positive ranking column")
         except Exception as e:
-            print(f"Method 1 failed: {e}")
-
-        # Method 2: If method 1 fails, try to locate through page layout
-        if not player_links_in_positive:
-            try:
-                print("Trying method 2: Locating Positive ranking through page layout...")
-
-                all_player_links = driver.find_elements(By.CSS_SELECTOR, "a[href*='/player/']")
-
-                size = driver.get_window_size()
-                for link in all_player_links:
-                    try:
-                        location = link.location
-
-                        if size['width'] * 0.33 < location['x'] < size['width'] * 0.66:
-                            player_links_in_positive.append(link)
-                    except Exception:
-                        continue
-
-                print(f"Method 2 found {len(player_links_in_positive)} possible Positive ranking links")
-
-            except Exception as e:
-                print(f"Method 2 also failed: {e}")
-
-        # Method 3: If both methods fail, get all player links and filter
-        if not player_links_in_positive:
-            print("Trying method 3: Getting all player links...")
-            all_links = driver.find_elements(By.TAG_NAME, "a")
-            for link in all_links:
-                href = link.get_attribute("href")
-                if href and "/player/" in href:
-                    player_links_in_positive.append(link)
-
-            print(f"Method 3 found {len(player_links_in_positive)} player links")
-            if len(player_links_in_positive) >= 60:
-                start_idx = len(player_links_in_positive) // 3
-                end_idx = start_idx + config.max_players_per_period
-                player_links_in_positive = player_links_in_positive[start_idx:end_idx]
-                print(f"After filtering, kept {len(player_links_in_positive)} Positive ranking links")
+            # 退路：找不到標題（版面再次改版時）就抓全部連結，至少不空手而回
+            print(f"Could not isolate Positive ranking column ({e}); falling back to all player links")
+            player_links_in_positive = driver.find_elements(By.CSS_SELECTOR, "a[href*='/player/']")
+            print(f"Fallback collected {len(player_links_in_positive)} player links (may include other columns)")
 
         # Extract specified number of unique player URLs
         seen_players = set()


### PR DESCRIPTION
## 摘要
本工作階段針對 GUI pipeline 的修復，並依需求**移除 dry-run** 功能。

### 1. 修復 Stage 1（爬 ID）auto 模式抓不到玩家
- 改用 `<h5>Positive ranking</h5>` → 父層 grid item 精準定位「Positive」欄，並在切換時間段 radio 後 `WebDriverWait` 等榜單重新渲染再抓。舊的「中間 1/3 / 抓全部」啟發式會抓到錯欄或空表，導致 0 筆。

### 2. 修復「取消沒反應、狀態卡在執行中」
- 根因：scrapy 預設 `LOG_LEVEL=DEBUG`，selenium `remote_connection` 把每個 WebDriver 指令（含整段 getAttribute JS）印出 → MB 級洪流 → 前端逐行寫 DOM、無上限累加 → 主執行緒卡死、取消鈕點不動。
- 治本：`selenium`/`urllib3` logger 提到 WARNING（crawl 輸出由數 MB → ~6KB）。
- 防護：renderer log 抽屜設 200KB 上限 + `requestAnimationFrame` 合併寫入，高頻輸出也不卡 UI。

### 3. 修復 dev 模式 `CRAWL_EXCEPTION`
- `subprocess.Popen(["scrapy", ...])` → `[sys.executable, "-m", "scrapy", ...]`。GUI 用 venv python 啟動後端、venv 的 Scripts 不在 PATH，裸 `scrapy` 會 FileNotFoundError。

### 4. 移除 dry-run（本次需求）
- UI toggle（step-crawl / step-download）、JS 參數串接（app.js → preload → main → pyRunner）、後端 `_dry_run` / `--dry-run`（run_crawler / run_download）、以及 smoke test 中依賴 dry-run 的步驟全部移除。

## 驗證
- `node --check` 所有改動的 JS：通過
- `py_compile` 後端：通過
- `npm test`（smoke，doctor 事件序列）：**SMOKE PASSED**
- 實跑 auto 爬取：正確抓到 Positive 欄玩家並收到 1 筆 paipu；crawl 輸出量從數 MB 降到 ~6KB

> 註：`paipu_project/paipu_project/crawler_config.json`（本機 auto 測試設定）未納入本 PR。